### PR TITLE
Fix for bug 816630

### DIFF
--- a/nova/network/manager.py
+++ b/nova/network/manager.py
@@ -1018,7 +1018,7 @@ class NetworkManager(manager.SchedulerDependentManager):
         ips = []
         for index in range(num_ips):
             address = str(project_net[index])
-            if index < bottom_reserved or num_ips - index < top_reserved:
+            if index < bottom_reserved or num_ips - index <= top_reserved:
                 reserved = True
             else:
                 reserved = False


### PR DESCRIPTION
"nova-manage network create" doesn't reserve the broadcast address correctly, thus broadcast address is assigned to VMs. 

https://bugs.launchpad.net/nova/+bug/816630
