### PR TITLE
Order by 'coalesced' value

### DIFF
--- a/nova/db/sqlalchemy/api.py
+++ b/nova/db/sqlalchemy/api.py
@@ -386,13 +386,14 @@ def service_get_all_compute_by_host(context, host):
 @require_admin_context
 def _service_get_all_topic_subquery(context, session, topic, subq, label):
     sort_value = getattr(subq.c, label)
+	 coal = func.coalesce(sort_value, 0)
     return model_query(context, models.Service,
-                       func.coalesce(sort_value, 0),
+			              coal,
                        session=session, read_deleted="no").\
                 filter_by(topic=topic).\
                 filter_by(disabled=False).\
                 outerjoin((subq, models.Service.host == subq.c.host)).\
-                order_by(sort_value).\
+                order_by(coal).\
                 all()
 
 


### PR DESCRIPTION
The _service_get_all_topic_subquery function orders by `label` and coalesce
`label` (with default 0). On Postgresql, <empty field> is geater than any number.
So we need to order by the coalesced value, not the (maybe empty) `label`.

I encountered the problem when I saw that with postgres, when we query the hosts with their use. the already used one is always on top of the result, because empty fields are not sorted the right way.

I will talk to the postgres crowd about that behaviour.
