### PR TITLE
create volume from imageRef (to boot from volume)

### DIFF
--- a/nova/api/openstack/compute/contrib/volumes.py
+++ b/nova/api/openstack/compute/contrib/volumes.py
@@ -243,6 +243,8 @@ class VolumeController(wsgi.Controller):
         LOG.audit(_("Create volume of %s GB"), size, context=context)
 
         availability_zone = vol.get('availability_zone', None)
+        
+        image_id = vol.get('imageRef',None)
 
         new_volume = self.volume_api.create(context,
                                             size,
@@ -251,7 +253,8 @@ class VolumeController(wsgi.Controller):
                                             snapshot=snapshot,
                                             volume_type=vol_type,
                                             metadata=metadata,
-                                            availability_zone=availability_zone
+                                            availability_zone=availability_zone,
+                                            image_id=image_id
                                            )
 
         # TODO(vish): Instance should be None at db layer instead of


### PR DESCRIPTION
Needed to BOOT from volume:

First create the volume with image:

POST /os-volumes

"volume": {
    "availability_zone": null, 
    "display_description": null, 
    "snapshot_id": null, 
    "user_id": null, 
    "size": 10, 
    "display_name": "my-volume", 
    "imageRef": "6ac70a85-b327-4f72-a31d-09443e713922", 
    "volume_type": null, 
}

and then, create the instance with this volume attached:

POST os-volumes_boot

"server":  {
    "name": "boot-from-volume",
    "imageRef": "6ac70a85-b327-4f72-a31d-09443e713922", 
    "block_device_mapping": 
        [{
        "volume_id":
            "b04b0e85-613d-41a2-8d2a-bf3b6dcb40f8", 
            "device_name": "vda"}
        ],
    "key_name": "yeaaaaaa",
    "flavorRef": "6",
    "max_count": 1,
    "min_count": 1}}'
