### PR TITLE
Fix incorrect LOG.error usage in _compare_cpu (LP:1076308)

### DIFF
--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -2373,7 +2373,7 @@ class LibvirtDriver(driver.ComputeDriver):
             raise
 
         if ret <= 0:
-            LOG.error(reason=m % locals())
+            LOG.error(m % locals())
             raise exception.InvalidCPUInfo(reason=m % locals())
 
     def _create_shared_storage_test_file(self):


### PR DESCRIPTION
Fix for https://bugs.launchpad.net/nova/+bug/1076308
