### PR TITLE
multi-region support in nova's compute client

### DIFF
--- a/etc/nova/nova.conf.sample
+++ b/etc/nova/nova.conf.sample
@@ -947,6 +947,9 @@
 # quantum_auth_strategy=keystone
 #### (StrOpt) auth strategy for connecting to quantum in admin context
 
+# quantum_region_name=RegionOne
+#### (StrOpt) region name for connecting to quantum in admin context
+
 
 ######## defined in nova.objectstore.s3server ########
 

--- a/nova/network/quantumv2/__init__.py
+++ b/nova/network/quantumv2/__init__.py
@@ -34,6 +34,7 @@ def _get_auth_token():
             password=CONF.quantum_admin_password,
             auth_url=CONF.quantum_admin_auth_url,
             timeout=CONF.quantum_url_timeout,
+            region_name=FLAGS.quantum_region_name,
             auth_strategy=CONF.quantum_auth_strategy)
         httpclient.authenticate()
     except Exception:

--- a/nova/network/quantumv2/api.py
+++ b/nova/network/quantumv2/api.py
@@ -44,6 +44,8 @@ quantum_opts = [
     cfg.StrOpt('quantum_admin_auth_url',
                default='http://localhost:5000/v2.0',
                help='auth url for connecting to quantum in admin context'),
+    cfg.StrOpt('quantum_region_name',
+               help='region name for connecting to quantum in admin context'),
     cfg.StrOpt('quantum_auth_strategy',
                default='keystone',
                help='auth strategy for connecting to '


### PR DESCRIPTION
This breaks multi-region setups that use a single keystone installation,
as multiple endpoints for quantum are otherwise returned.

Signed-off-by: Stephen Gran Stephen.Gran@guardian.co.uk
