### PR TITLE
Explain the magic 65537 constant.

### DIFF
--- a/nova/crypto.py
+++ b/nova/crypto.py
@@ -136,7 +136,7 @@ def generate_fingerprint(public_key):
 
 
 def generate_key_pair(bits=1024):
-    # what is the magic 65537?
+    # 65537 is constant public exponent defined in RFC for RSA cipher.
 
     with utils.tempdir() as tmpdir:
         keyfile = os.path.join(tmpdir, 'temp')


### PR DESCRIPTION
RFC 4871 insists on using 65537 (0x10001) as a public exponent parameter for RSA based algorithms.
The value has been chosen by cryptography engineers after security analysis of short and long public exponents that may lead to security flaws in the algorithm.
