### PR TITLE
Fix the libguestfs error when /dev/vda1 is the boot dir -- mount_options...

### DIFF
--- a/nova/virt/disk/vfs/guestfs.py
+++ b/nova/virt/disk/vfs/guestfs.py
@@ -87,6 +87,16 @@ class VFSGuestFS(vfs.VFS):
                 {'root': root, 'imgfile': self.imgfile})
 
         mounts.sort(key=lambda mount: mount[1])
+
+        # the root directory must be mounted first
+        mounts_tmp = []
+        for mount in mounts:
+            if mount[0] == "/":
+                mounts_tmp.insert(0, mount)
+            else:
+                mounts_tmp.append(mount)
+        mounts = mounts_tmp
+
         for mount in mounts:
             LOG.debug(_("Mounting %(dev)s at %(dir)s") %
                       {'dev': mount[1], 'dir': mount[0]})


### PR DESCRIPTION
error log:
mount_options: mount: /boot: No such file or directory

reason:
variable `mounts` sorted value is [('/boot', '/dev/vda1'), ('/', '/dev/vda2'), ('/var', '/dev/vda5'), ('/home', '/dev/vda6'), ('/home/q', '/dev/vda7')], but `/boot` directory is in `/` partition.
