### PR TITLE
Fixed 1245466 - Nova Docker driver cannot destroy instance 

### DIFF
--- a/nova/virt/docker/driver.py
+++ b/nova/virt/docker/driver.py
@@ -316,7 +316,7 @@ class DockerDriver(driver.ComputeDriver):
                                                   instance_id=instance['name'])
 
     def destroy(self, instance, network_info, block_device_info=None,
-                destroy_disks=True):
+                destroy_disks=True, context=None):
         container_id = self.find_container_by_name(instance['name']).get('id')
         if not container_id:
             return


### PR DESCRIPTION
In some case is openstack not able to destroy/remove a instance
completely. The reason for that is that the destroy method in the docker
driver doesn't provide the optional "context" parameter.

Bug: https://bugs.launchpad.net/neutron/+bug/1245466
