### PR TITLE
Added RBD direct image download scheme for Nova

### DIFF
--- a/nova/image/download/rbd.py
+++ b/nova/image/download/rbd.py
@@ -1,0 +1,38 @@
+# Copyright 2013 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from oslo_config import cfg
+from oslo_log import log as logging
+
+from nova import exception
+from nova.i18n import _, _LI
+import nova.image.download.base as xfer_base
+from nova.virt.libvirt import imagebackend
+
+CONF = cfg.CONF
+LOG = logging.getLogger(__name__)
+
+class RBDTransfer(xfer_base.TransferBase):
+
+    def download(self, context, url_parts, dst_file, metadata, **kwargs):
+        Rbd = imagebackend.Rbd(path = url_parts.path)
+        Rbd.export_image(url_parts, dst_file)
+
+def get_download_handler(**kwargs):
+    return RBDTransfer()
+
+
+def get_schemes():
+    return ['rbd']

--- a/nova/image/glance.py
+++ b/nova/image/glance.py
@@ -71,7 +71,7 @@ glance_opts = [
                 default=[],
                 help='A list of url scheme that can be downloaded directly '
                      'via the direct_url.  Currently supported schemes: '
-                     '[file].'),
+                     '[file, rbd].'),
     ]
 
 LOG = logging.getLogger(__name__)

--- a/nova/virt/libvirt/imagebackend.py
+++ b/nova/virt/libvirt/imagebackend.py
@@ -877,6 +877,9 @@ class Rbd(Image):
         if os.path.exists(local_file):
             os.unlink(local_file)
 
+    def export_image(self, image_url_parts, dst_path):
+        return self.driver.export_image(image_url_parts, dst_path)
+
 
 class Ploop(Image):
     def __init__(self, instance=None, disk_name=None, path=None):

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ nova.compute.resources =
     vcpu = nova.compute.resources.vcpu:VCPU
 nova.image.download.modules =
     file = nova.image.download.file
+    rbd = nova.image.download.rbd
 console_scripts =
     nova-all = nova.cmd.all:main
     nova-api = nova.cmd.api:main


### PR DESCRIPTION
Added RBD direct image download scheme for Nova

Inspired by https://review.openstack.org/37817
 
Added new rbd download scheme for Nova. With that change 
Nova can download RBD images directly from Ceph using 'rbd export' 
command not involving rather slow download by HTTP from Glance 
server. That makes image download process much faster if local 
disks storage is configured for Nova.

Option must be set in nova.conf:
allowed_direct_url_schemes = rbd
Also Nova must have read access to images pool in Ceph.

Change-Id: I9c3b45d7e0aeadbe5aa49f5339cf27ee262e51ae