### PR TITLE
Typo changed from "explicitely" to "explicitly"

### DIFF
--- a/etc/nova/rootwrap.conf
+++ b/etc/nova/rootwrap.conf
@@ -7,7 +7,7 @@
 filters_path=/etc/nova/rootwrap.d,/usr/share/nova/rootwrap
 
 # List of directories to search executables in, in case filters do not
-# explicitely specify a full path (separated by ',')
+# explicitly specify a full path (separated by ',')
 # If not specified, defaults to system PATH environment variable.
 # These directories MUST all be only writeable by root !
 exec_dirs=/sbin,/usr/sbin,/bin,/usr/bin

--- a/nova/network/manager.py
+++ b/nova/network/manager.py
@@ -638,7 +638,7 @@ class NetworkManager(manager.Manager):
                 except (TypeError, KeyError):
                     pass
                 if fixed_ip.network.cidr_v6 and vif.address:
-                    # NOTE(vish): I strongy suspect the v6 subnet is not used
+                    # NOTE(vish): I strongly suspect the v6 subnet is not used
                     #             anywhere, but support it just in case
                     # add the v6 address to the v6 subnet
                     address = ipv6.to_global(fixed_ip.network.cidr_v6,

--- a/nova/objects/instance_group.py
+++ b/nova/objects/instance_group.py
@@ -135,7 +135,7 @@ class InstanceGroup(base.NovaPersistentObject, base.NovaObject,
         # InstanceGroup.add_members() method is called, which adds the mapping
         # table entries.
         # So, since the only way to have hosts in the updates is to set that
-        # field explicitely, we prefer to raise an Exception so the developer
+        # field explicitly, we prefer to raise an Exception so the developer
         # knows he has to call obj_reset_changes(['hosts']) right after setting
         # the field.
         if 'hosts' in updates:

--- a/nova/objects/pci_device.py
+++ b/nova/objects/pci_device.py
@@ -134,7 +134,7 @@ class PciDevice(base.NovaPersistentObject, base.NovaObject):
                 setattr(self, k, v)
             else:
                 # Note (yjiang5) extra_info.update does not update
-                # obj_what_changed, set it explicitely
+                # obj_what_changed, set it explicitly
                 extra_info = self.extra_info
                 extra_info.update({k: v})
                 self.extra_info = extra_info

--- a/nova/virt/xenapi/vmops.py
+++ b/nova/virt/xenapi/vmops.py
@@ -1958,7 +1958,7 @@ class VMOps(object):
     def _read_from_xenstore(self, instance, path, ignore_missing_path=True,
                             vm_ref=None):
         """Reads the passed location from xenstore for the given vm.
-        Missing paths are ignored, unless explicitely stated not to
+        Missing paths are ignored, unless explicitly stated not to
         which will cause and exception to be raised by xenstore.
         A XenAPIPlugin.PluginError will be raised if any error is
         encountered in the read process.


### PR DESCRIPTION
Typo changed from "explicitely" to "explicitly".
Bug #1501202 (https://bugs.launchpad.net/nova/+bug/1501202)
Resolved.