### PR TITLE
calling ip route del before ip link delete for delete_net_dev

### DIFF
--- a/nova/network/linux_net.py
+++ b/nova/network/linux_net.py
@@ -1417,6 +1417,14 @@ def delete_net_dev(dev):
     """Delete a network device only if it exists."""
     if device_exists(dev):
         try:
+            out, err = _execute('ip', 'route', 'show', 'dev', dev)
+            fields = out.split()
+            try:
+                field = fields[0]
+                _execute('ip', 'route', 'del', fields[0],
+                               'dev', dev, run_as_root=True)
+            except IndexError:
+                pass
             utils.execute('ip', 'link', 'delete', dev, run_as_root=True,
                           check_exit_code=[0, 2, 254])
             LOG.debug("Net device removed: '%s'", dev)


### PR DESCRIPTION
quagga/zebra look for netlink event and since ip link delete does not trigger any event route is never deleted in quagga/zebra and yet still advertised over bgp/ospf...