### PR TITLE
Please make the build reproducible

### DIFF
--- a/nova/conf/paths.py
+++ b/nova/conf/paths.py
@@ -22,6 +22,7 @@ from oslo_config import cfg
 
 ALL_OPTS = [
     cfg.StrOpt('pybasedir',
+        sample_default='<Path>',
         default=os.path.abspath(os.path.join(os.path.dirname(__file__),
                                              '../../')),
         help="""


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed
that nova could not be built reproducibly as the docs etc contain
the absolute build path.

This was originally filed in Debian as #892420

 [0] https://reproducible-builds.org/
 [1] https://bugs.debian.org/892420

Signed-off-by: Chris Lamb <lamby@debian.org>