### PR TITLE
Added [key_pairs]/fingerprint_algorithm options

### DIFF
--- a/nova/conf/__init__.py
+++ b/nova/conf/__init__.py
@@ -39,6 +39,7 @@ from nova.conf import guestfs
 from nova.conf import hyperv
 from nova.conf import ironic
 from nova.conf import key_manager
+from nova.conf import key_pairs
 from nova.conf import keystone
 from nova.conf import libvirt
 from nova.conf import mks
@@ -95,6 +96,7 @@ hyperv.register_opts(CONF)
 mks.register_opts(CONF)
 ironic.register_opts(CONF)
 key_manager.register_opts(CONF)
+key_pairs.register_opts(CONF)
 keystone.register_opts(CONF)
 libvirt.register_opts(CONF)
 netconf.register_opts(CONF)

--- a/nova/conf/key_pairs.py
+++ b/nova/conf/key_pairs.py
@@ -1,0 +1,52 @@
+# Copyright 2018 OpenStack Foundation
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from oslo_config import cfg
+
+
+key_pairs_group = cfg.OptGroup('key_pairs',
+    title='SSH key pairs options',
+    help="""
+Options under this group are used to define Nova SSH key pairs.
+""")
+
+crypto_opts = [
+    cfg.StrOpt("fingerprint_algorithm",
+        default="md5",
+        choices=[
+            ("md5", "Use MD5 for fingerprinting"),
+            ("sha1", "Use SHA-1 for fingerprinting"),
+            ("sha256", "Use SHA-256 for fingerprinting")
+        ],
+        help="""
+This controls the hashing algorithm used for creating SSH
+public key fingerprints. This should not be adjusted after
+deployment or after SSH key pairs have been generated. Care
+should also be taken to ensure the database column holding the
+key pair fingerprint is wide enough for the resulting fingerprint.
+""")
+]
+
+
+KEY_PAIRS_OPTS = (crypto_opts)
+
+
+def register_opts(conf):
+    conf.register_group(key_pairs_group)
+    conf.register_opts(KEY_PAIRS_OPTS, group=key_pairs_group)
+
+
+def list_opts():
+    return {key_pairs_group: KEY_PAIRS_OPTS}


### PR DESCRIPTION
This is one of the issues found when deploying Red Hat OpenStack 10 and 13 (Newton and Queens respectively) on "FIPS mode" systems (those with fips=1 kernel flag). MD5 is, for the most part, not allowed with FIPS 140-2 solutions so this patch gives users the option to change the SSH key pair fingerprint hash algorithm between md5, sha1, and sha256. 