### PR TITLE
Update imagecache.py

### DIFF
--- a/nova/conf/imagecache.py
+++ b/nova/conf/imagecache.py
@@ -59,7 +59,11 @@ For per-compute-host cached images, set to '_base_$my_ip'
     cfg.BoolOpt('remove_unused_base_images',
         default=True,
         deprecated_group='DEFAULT',
-        help='Should unused base images be removed?'),
+        help="""
+Should unused base images be removed?
+
+When there are no remaining instances on the hypervisor created from this base image or linked to it, the base image is considered unused.
+"""),
     cfg.IntOpt('remove_unused_original_minimum_age_seconds',
         default=(24 * 3600),
         deprecated_group='DEFAULT',


### PR DESCRIPTION
Explaining when a base image is considered unused to avoid confusion, especially why certain images aren't deleted.