### PR TITLE
docs: Fix a few typos

### DIFF
--- a/doc/source/user/cells.rst
+++ b/doc/source/user/cells.rst
@@ -342,7 +342,7 @@ of ``rabbit://bob:s3kret@otherhost/nova`` when used with the above example.
 .. note:: The ``[DEFAULT]/transport_url`` option can contain an
    extended syntax for the "netloc" part of the url
    (i.e. `userA:passwordA@hostA:portA,userB:passwordB:hostB:portB`). In this
-   case, substitions of the form ``username1``, ``username2``, etc will be
+   case, substitutions of the form ``username1``, ``username2``, etc will be
    honored and can be used in the template URL.
 
 The templating of these URLs may be helpful in order to provide each service host

--- a/nova/tests/fixtures/nova.py
+++ b/nova/tests/fixtures/nova.py
@@ -709,7 +709,7 @@ class RPCFixture(fixtures.Fixture):
 
         # NOTE(danms): This will be called with a non-None url by
         # cells-aware code that is requesting to contact something on
-        # one of the many transports we're multplexing here.
+        # one of the many transports we're multiplexing here.
         if url not in self._buses:
             exmods = rpc.get_allowed_exmods()
             self._buses[url] = messaging.get_rpc_transport(

--- a/nova/tests/functional/libvirt/test_pci_sriov_servers.py
+++ b/nova/tests/functional/libvirt/test_pci_sriov_servers.py
@@ -624,7 +624,7 @@ class SRIOVServersTest(_PCIServersTestBase):
         pci_info = fakelibvirt.HostPCIDevicesInfo(num_pfs=1, num_vfs=1)
         pci_info_no_sriov = copy.deepcopy(pci_info)
 
-        # Disable SRIOV capabilties in PF and delete the VFs
+        # Disable SRIOV capabilities in PF and delete the VFs
         self._disable_sriov_in_pf(pci_info_no_sriov)
 
         fake_connection = self._get_connection(pci_info=pci_info_no_sriov,

--- a/nova/tests/unit/compute/test_compute.py
+++ b/nova/tests/unit/compute/test_compute.py
@@ -7379,7 +7379,7 @@ class ComputeTestCase(BaseTestCase,
             fake_instance.fake_db_instance(uuid=uuids.migration_instance_5,
                                            vm_state=vm_states.ACTIVE,
                                            task_state=None),
-            # The expceted migration result will be None instead of error
+            # The expected migration result will be None instead of error
             # since _poll_unconfirmed_resizes will not change it
             # when the instance vm state is RESIZED and task state
             # is deleting, see bug 1301696 for more detail

--- a/nova/tests/unit/policies/test_server_ips.py
+++ b/nova/tests/unit/policies/test_server_ips.py
@@ -57,7 +57,7 @@ class ServerIpsPolicyTest(base.BasePolicyTest):
             self.project_reader_context, self.project_foo_context,
             self.system_member_context, self.system_reader_context]
         # Check that non-admin/owner is not able to get the server IP
-        # adderesses
+        # addresses
         self.reader_or_owner_unauthorized_contexts = [
             self.system_foo_context,
             self.other_project_member_context,
@@ -108,13 +108,13 @@ class ServerIpsNoLegacyPolicyTest(ServerIpsScopeTypePolicyTest):
         super(ServerIpsNoLegacyPolicyTest, self).setUp()
 
         # Check that system reader or owner is able to
-        # get the server IP adderesses.
+        # get the server IP addresses.
         self.reader_or_owner_authorized_contexts = [
             self.system_admin_context, self.system_member_context,
             self.system_reader_context, self.project_admin_context,
             self.project_member_context, self.project_reader_context]
         # Check that non-system and non-owner is not able to
-        # get the server IP adderesses.
+        # get the server IP addresses.
         self.reader_or_owner_unauthorized_contexts = [
             self.legacy_admin_context, self.project_foo_context,
             self.system_foo_context, self.other_project_member_context,

--- a/nova/tests/unit/virt/test_hardware.py
+++ b/nova/tests/unit/virt/test_hardware.py
@@ -2867,7 +2867,7 @@ class VirtNUMAHostTopologyTestCase(test.NoDBTestCase):
         # the PCI device is found on host cell 1
         pci_stats = _create_pci_stats(1)
 
-        # ...threfore an instance without a PCI device should get host cell 2
+        # ...therefore an instance without a PCI device should get host cell 2
         instance_topology = hw.numa_fit_instance_to_host(
                 self.host, self.instance1, pci_stats=pci_stats)
         self.assertIsInstance(instance_topology, objects.InstanceNUMATopology)
@@ -2877,7 +2877,7 @@ class VirtNUMAHostTopologyTestCase(test.NoDBTestCase):
         # the PCI device is now found on host cell 2
         pci_stats = _create_pci_stats(2)
 
-        # ...threfore an instance without a PCI device should get host cell 1
+        # ...therefore an instance without a PCI device should get host cell 1
         instance_topology = hw.numa_fit_instance_to_host(
                 self.host, self.instance1, pci_stats=pci_stats)
         self.assertIsInstance(instance_topology, objects.InstanceNUMATopology)

--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -8018,7 +8018,7 @@ class LibvirtDriver(driver.ComputeDriver):
         for cell in topology.cells:
             cpus = set(cpu.id for cpu in cell.cpus)
 
-            # NOTE(artom) We assume we'll never see hardware with multipe
+            # NOTE(artom) We assume we'll never see hardware with multiple
             # sockets in a single NUMA node - IOW, the socket_id for all CPUs
             # in a single cell will be the same. To make that assumption
             # explicit, we leave the cell's socket_id as None if that's the


### PR DESCRIPTION
There are small typos in:
- doc/source/user/cells.rst
- nova/tests/fixtures/nova.py
- nova/tests/functional/libvirt/test_pci_sriov_servers.py
- nova/tests/unit/compute/test_compute.py
- nova/tests/unit/policies/test_server_ips.py
- nova/tests/unit/virt/test_hardware.py
- nova/virt/libvirt/driver.py

Fixes:
- Should read `addresses` rather than `adderesses`.
- Should read `therefore` rather than `threfore`.
- Should read `substitutions` rather than `substitions`.
- Should read `multiplexing` rather than `multplexing`.
- Should read `multiple` rather than `multipe`.
- Should read `expected` rather than `expceted`.
- Should read `capabilities` rather than `capabilties`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md