### PR TITLE
vGPU instance creating error by "ValueError: badly formed hexadecimal UUID string"

### DIFF
--- a/nova/virt/libvirt/utils.py
+++ b/nova/virt/libvirt/utils.py
@@ -578,7 +578,7 @@ def mdev_name2uuid(mdev_name: str) -> str:
     """Convert an mdev name (of the form mdev_<uuid_with_underscores>) to a
     uuid (of the form 8-4-4-4-12).
     """
-    return str(uuid.UUID(mdev_name[5:].replace('_', '-')))
+    return str(uuid.UUID(mdev_name[5:41].replace('_', '-')))
 
 
 def mdev_uuid2name(mdev_uuid: str) -> str:


### PR DESCRIPTION
When openstack links to Nvidia Tesla A40 for GPU instances, The UUID format is wrong.
Check below an error log.

2022-10-26 22:08:14.102 7 ERROR nova.compute.manager [req-d9062726-82b9-4039-997b-88167427a00b - - - - -] Error updating resources for node compute02.: ValueError: badly formed hexadecimal UUID string

So I checked a value of 'mdev_name[5:]' and then I found a problem.
mdev_name[5:] 's value: 5da919f7-1ffc-405e-832c-71686f8c2862-0000-ca-01-2

I had to remove '-0000-ca-01-2' part and I solved a problem as using a string slicing function.

Example:
Before: 5da919f7-1ffc-405e-832c-71686f8c2862-0000-ca-01-2
After: 5da919f7-1ffc-405e-832c-71686f8c2862