### PR TITLE
replace genisoimage to xorrisofs

### DIFF
--- a/doc/source/admin/config-drive.rst
+++ b/doc/source/admin/config-drive.rst
@@ -43,9 +43,9 @@ The following virt drivers support the config drive: libvirt, Hyper-V and
 VMware. The Bare Metal service also supports the config drive.
 
 - To use config drives with libvirt or VMware, you must first
-  install the :command:`genisoimage` package on each compute host. Use the
+  install the :command:`xorrisofs` package on each compute host. Use the
   :oslo.config:option:`mkisofs_cmd` config option to set the path where you
-  install the :command:`genisoimage` program. If :command:`genisoimage` is in
+  install the :command:`xorrisofs` program. If :command:`xorrisofs` is in
   the same path as the :program:`nova-compute` service, you do not need to set
   this flag.
 

--- a/doc/source/install/compute-install-obs.rst
+++ b/doc/source/install/compute-install-obs.rst
@@ -28,7 +28,7 @@ Install and configure components
 
    .. code-block:: console
 
-      # zypper install openstack-nova-compute genisoimage qemu-kvm libvirt
+      # zypper install openstack-nova-compute xorrisofs qemu-kvm libvirt
 
 #. Edit the ``/etc/nova/nova.conf`` file and complete the following actions:
 

--- a/nova/conf/configdrive.py
+++ b/nova/conf/configdrive.py
@@ -69,7 +69,7 @@ Possible values:
 Related options:
 
 * Use the 'mkisofs_cmd' flag to set the path where you install the
-  genisoimage program. If genisoimage is in same path as the
+  xorrisofs program. If xorrisofs is in same path as the
   nova-compute service, you do not need to set this flag.
 * To use a config drive with Hyper-V, you must set the
   'mkisofs_cmd' value to the full path to an mkisofs.exe installation.
@@ -78,12 +78,12 @@ Related options:
   installation.
 """),
     cfg.StrOpt('mkisofs_cmd',
-        default='genisoimage',
+        default='xorrisofs',
         help="""
 Name or path of the tool used for ISO image creation.
 
 Use the ``mkisofs_cmd`` flag to set the path where you install the
-``genisoimage`` program. If ``genisoimage`` is on the system path, you do not
+``xorrisofs`` program. If ``xorrisofs`` is on the system path, you do not
 need to change the default value.
 
 To use a config drive with Hyper-V, you must set the ``mkisofs_cmd`` value to

--- a/nova/tests/unit/test_configdrive2.py
+++ b/nova/tests/unit/test_configdrive2.py
@@ -49,10 +49,10 @@ class ConfigDriveTestCase(test.NoDBTestCase):
                 os.close(fd)
                 c.make_drive(imagefile)
 
-            mock_execute.assert_called_once_with('genisoimage', '-o',
+            mock_execute.assert_called_once_with('xorrisofs', '-o',
                                                  mock.ANY,
-                                                 '-ldots', '-allow-lowercase',
-                                                 '-allow-multidot', '-l',
+                                                 '-allow-lowercase',
+                                                 '-l',
                                                  '-publisher',
                                                  mock.ANY,
                                                  '-quiet', '-J', '-r',

--- a/nova/virt/configdrive.py
+++ b/nova/virt/configdrive.py
@@ -83,9 +83,7 @@ class ConfigDriveBuilder(object):
 
         processutils.execute(CONF.mkisofs_cmd,
                              '-o', path,
-                             '-ldots',
                              '-allow-lowercase',
-                             '-allow-multidot',
                              '-l',
                              '-publisher',
                              publisher,
@@ -99,7 +97,7 @@ class ConfigDriveBuilder(object):
 
     def _make_vfat(self, path, tmpdir):
         # NOTE(mikal): This is a little horrible, but I couldn't find an
-        # equivalent to genisoimage for vfat filesystems.
+        # equivalent to xorrisofs for vfat filesystems.
         with open(path, 'wb') as f:
             f.truncate(CONFIGDRIVESIZE_BYTES)
 


### PR DESCRIPTION
genisoimage in cdrkit has not been maintained for a long time, the modern replacement available is from xorriso, which looks like it supports all the features that exist in our variant of genisoimage.