### PR TITLE
PoC: priority core pinning

### DIFF
--- a/nova/conf/compute.py
+++ b/nova/conf/compute.py
@@ -878,7 +878,26 @@ Related options:
   where ``VCPU`` resources should be allocated from.
 * ``vcpu_pin_set``: A legacy option that this option partially replaces.
 """),
-    cfg.BoolOpt('live_migration_wait_for_vif_plug',
+   cfg.StrOpt('cpu_high_priority_set',
+        help="""
+Mask of host CPUs that can be used for prioritized ``PCPU`` resources.
+
+Possible values:
+
+* A comma-separated list of physical CPU numbers that instance VCPUs can be
+  allocated from. Each element should be either a single CPU number, a range of
+  CPU numbers, or a caret followed by a CPU number to be excluded from a
+  previous range. For example::
+
+    cpu_dedicated_set = "4-12,^8,15"
+
+Related options:
+
+* ``[compute] cpu_dedicated_set``: This is the parent option for defining the superset
+  where ``VCPU`` resources should be allocated from. ``[compute] cpu_high_priority_set`` option complements 
+  this option by enabling physical CPU prioritization.
+"""),
+   cfg.BoolOpt('live_migration_wait_for_vif_plug',
         default=True,
         help="""
 Determine if the source compute host should wait for a ``network-vif-plugged``

--- a/nova/virt/hardware.py
+++ b/nova/virt/hardware.py
@@ -76,6 +76,22 @@ def get_cpu_dedicated_set():
     return cpu_ids
 
 
+def get_cpu_high_priority_set():
+    """Parse ``[compute] cpu_high_priority_set`` config.
+
+    :returns: A set of host CPU IDs that can be used for prioritized PCPU allocations.
+    """
+    if not CONF.compute.cpu_high_priority_set:
+        return None
+
+    cpu_ids = parse_cpu_spec(CONF.compute.cpu_high_priority_set)
+    if not cpu_ids:
+        msg = _("No CPUs available after parsing '[compute] "
+                "cpu_high_priority_set' config, %r")
+        raise exception.Invalid(msg % CONF.compute.cpu_high_priority_set)
+    return cpu_ids
+
+
 def get_cpu_dedicated_set_nozero():
     """Return cpu_dedicated_set without CPU0, if present"""
     return (get_cpu_dedicated_set() or set()) - {0}
@@ -720,8 +736,29 @@ def _pack_instance_onto_cores(host_cell, instance_cell,
         #
         # For an instance_cores=[2, 3], usable_cores=[[0], [4]]
         # vcpus_pinning=[(2, 0), (3, 4)]
-        vcpus_pinning = list(zip(sorted(instance_cores),
-                                 itertools.chain(*usable_cores)))
+
+        # todo  Tharindu: Below is PoC implementation, and not efficient at all.
+        def get_priority_weight(val, high_p_list):
+            if val in high_p_list:
+                return 0
+            return 1
+
+        high_priority_cores = get_cpu_high_priority_set()
+        usable_cores_list = list(itertools.chain(*usable_cores))
+        if len(high_priority_cores) > 1:
+            usable_cores_list = sorted(usable_cores_list, key=lambda x: get_priority_weight(x, high_priority_cores))
+            msg = ("Using priority core pinning: high priority cores: "
+                   "%(high_priority_cores)s, priority ordered host cores: %(usable_cores_list)s")
+            msg_args = {
+                'high_priority_cores': high_priority_cores,
+                'usable_cores_list': usable_cores_list,
+            }
+            LOG.info(msg, msg_args)
+        vcpus_pinning = list(zip(
+            sorted(instance_cores),
+            usable_cores_list
+        ))
+
         msg = ("Computed NUMA topology CPU pinning: usable pCPUs: "
                "%(usable_cores)s, vCPUs mapping: %(vcpus_pinning)s")
         msg_args = {
@@ -729,6 +766,8 @@ def _pack_instance_onto_cores(host_cell, instance_cell,
             'vcpus_pinning': vcpus_pinning,
         }
         LOG.info(msg, msg_args)
+        # In the prototype: Allocate vm with pinnning enabled + number of cores = 1
+        # Computed NUMA topology CPU pinning: usable pCPUs: [[0], [1], [2], [3]], vCPUs mapping: [(0, 0)]
 
         return vcpus_pinning
 


### PR DESCRIPTION
Fixes https://github.com/crunchycookie/openstack-gc/issues/13

Existing core pinning does not allow pinning order. This commit allows configuring two core priority levels; high and low. Below config makes first three cores high priority.

```
[compute]
cpu_high_priority_set=[0,1,2]
```
During pinning, if available, high priority cores are attempted first. If not enough, low priority cores are used.