### PR TITLE
Replace paramiko with ssh-python

### DIFF
--- a/nova/tests/unit/test_crypto.py
+++ b/nova/tests/unit/test_crypto.py
@@ -23,9 +23,9 @@ from unittest import mock
 from castellan.common import exception as castellan_exception
 from cryptography.hazmat import backends
 from cryptography.hazmat.primitives import serialization
+from ssh import key as libssh_key
 from oslo_concurrency import processutils
 from oslo_utils.fixture import uuidsentinel as uuids
-import paramiko
 
 from nova import context as nova_context
 from nova import crypto
@@ -213,9 +213,9 @@ class KeyPairTest(test.NoDBTestCase):
         keyin = io.StringIO()
         keyin.write(self.rsa_prv)
         keyin.seek(0)
-        key = paramiko.RSAKey.from_private_key(keyin)
+        key = libssh_key.import_privkey_base64(str.encode(self.rsa_prv))
 
-        with mock.patch.object(paramiko.RSAKey, 'generate') as mock_generate:
+        with mock.patch.object(libssh_key, 'generate') as mock_generate:
             mock_generate.return_value = key
             (private_key, public_key, fingerprint) = crypto.generate_key_pair()
             self.assertEqual(self.rsa_pub, public_key)

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ Paste>=2.0.2 # MIT
 PrettyTable>=0.7.1 # BSD
 alembic>=1.5.0 # MIT
 netaddr>=0.7.18 # BSD
-paramiko>=2.7.1 # LGPLv2.1+
 iso8601>=0.1.11 # MIT
 jsonschema>=4.0.0 # MIT
 python-cinderclient>=4.0.1 # Apache-2.0
@@ -63,3 +62,4 @@ python-dateutil>=2.7.0 # BSD
 futurist>=1.8.0 # Apache-2.0
 openstacksdk>=4.4.0 # Apache-2.0
 PyYAML>=5.1 # MIT
+ssh-python==1.1.1 # LGPLv2.1


### PR DESCRIPTION
paramiko uses some crypto that are not compatible with FIPS. ssh-python is a binding for libssh, which is FIPS compatible.