### PR TITLE
OpenStack Nova API Documentation Fix: Volume Attachment Response Consistency

### DIFF
--- a/api-ref/source/parameters.yaml
+++ b/api-ref/source/parameters.yaml
@@ -1815,7 +1815,7 @@ attachment_id_put_req:
   min_version: 2.85
 attachment_id_resp:
   description: |
-    The UUID of the attachment.
+    The volume ID of the attachment.
   in: body
   required: false
   type: string


### PR DESCRIPTION
# Background
The OpenStack Nova API has inconsistent parameter descriptions across different volume attachment endpoints, which can cause confusion for API users. Specifically, the id field in volume attachment responses has different descriptions despite returning the same type of value (volume ID) across all three APIs.

# Problem Description
## Current State (Inconsistent)

| API Endpoint | `id` Description | `volumeId` Description |
|-------------|------------------|------------------------|
| **List volume attachments** | "The volume ID of the attachment" | "The UUID of the attached volume" |
| **Show volume attachment detail** | "The volume ID of the attachment" | "The UUID of the attached volume" |
| **Attach volume to instance** | **"The UUID of the attachment"** | "The UUID of the attached volume" |


### Issue

The **Attach volume to instance** API has a different description for the `id` field ("The UUID of the attachment") compared to the other two APIs ("The volume ID of the attachment"), even though all three APIs return the same value type - the volume ID.

## Actual API Response Behavior
All three APIs return identical response structures where both `id` and `volumeId` contain the same volume UUID value:



## Response Examples
### "List volume attachments for an instance" 
- GET /servers/{server_id}/os-volume_attachments
```json
{
    "volumeAttachments": [
        {
            "device": "/dev/sdc",
            "id": "227cc671-f30b-4488-96fd-7d0bf13648d8",
            "serverId": "4b293d31-ebd5-4a7f-be03-874b90021e54",
            "volumeId": "227cc671-f30b-4488-96fd-7d0bf13648d8"
        },
        {
            "device": "/dev/sdb",
            "id": "a07f71dc-8151-4e7d-a0cc-cd24a3f11113",
            "serverId": "4b293d31-ebd5-4a7f-be03-874b90021e54",
            "volumeId": "a07f71dc-8151-4e7d-a0cc-cd24a3f11113"
        }
    ]
}
```
### "Show a detail of a volume attachment"
- GET /servers/{server_id}/os-volume_attachments/{volume_id}
```json
{
    "volumeAttachment": {
        "device": "/dev/sdb",
        "id": "a07f71dc-8151-4e7d-a0cc-cd24a3f11113",
        "serverId": "1ad6852e-6605-4510-b639-d0bff864b49a",
        "volumeId": "a07f71dc-8151-4e7d-a0cc-cd24a3f11113"
    }
}
```
### "Attach a volume to an instance"
- POST /servers/{server_id}/os-volume_attachments
```json
{
    "volumeAttachment": {
        "device": "/dev/sdb",
        "id": "a07f71dc-8151-4e7d-a0cc-cd24a3f11113",
        "serverId": "802db873-0373-4bdd-a433-d272a539ba18",
        "volumeId": "a07f71dc-8151-4e7d-a0cc-cd24a3f11113"
    }
}
```
<img width="702" height="510" alt="스크린샷 2025-08-21 오후 11 13 02" src="https://github.com/user-attachments/assets/03bb7641-19cd-4193-ad84-1ead9c2157e7" />
